### PR TITLE
Patch for FOP-2704 to make Google Roboto font usable

### DIFF
--- a/fop-core/pom.xml
+++ b/fop-core/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <properties>
@@ -22,32 +22,32 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-anim</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-awt-util</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-bridge</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-extension</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-gvt</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-transcoder</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <!-- fop deps -->
     <dependency>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>xmlgraphics-commons</artifactId>
-      <version>${xmlgraphics.commons.version}</version>
+      <version>2.3</version>
     </dependency>
     <!-- xmlgraphics external deps -->
     <dependency>

--- a/fop-core/src/main/java/org/apache/fop/complexscripts/fonts/OTFAdvancedTypographicTableReader.java
+++ b/fop-core/src/main/java/org/apache/fop/complexscripts/fonts/OTFAdvancedTypographicTableReader.java
@@ -3336,7 +3336,12 @@ public final class OTFAdvancedTypographicTableReader {
             msca[i] = readCoverageTable(tableTag + " mark set coverage[" + i + "]", subtableOffset + mso[i]);
         }
         // create combined class table from per-class coverage tables
-        GlyphClassTable ct = GlyphClassTable.createClassTable(Arrays.asList(msca));
+        GlyphClassTable ct = null;
+        try {
+            ct = GlyphClassTable.createClassTable(Arrays.asList(msca));
+        } catch (UnsupportedOperationException uoe) {
+            log.debug(uoe.getMessage(), uoe);
+        }
         // store results
         seMapping = ct;
         // extract subtable
@@ -3580,14 +3585,16 @@ public final class OTFAdvancedTypographicTableReader {
     }
 
     private void constructLookupsLanguage(Map lookups, String st, String lt, Map<String, Object> languages) {
+        if (languages != null) {
         Object[] lp = (Object[]) languages.get(lt);
-        if (lp != null) {
-            assert lp.length == 2;
-            if (lp[0] != null) {                      // required feature id
-                constructLookupsFeature(lookups, st, lt, (String) lp[0]);
-            }
-            if (lp[1] != null) {                      // non-required features ids
-                constructLookupsFeatures(lookups, st, lt, (List) lp[1]);
+            if (lp != null) {
+                assert lp.length == 2;
+                if (lp[0] != null) {                      // required feature id
+                    constructLookupsFeature(lookups, st, lt, (String) lp[0]);
+                }
+                if (lp[1] != null) {                      // non-required features ids
+                    constructLookupsFeatures(lookups, st, lt, (List) lp[1]);
+                }
             }
         }
     }

--- a/fop-events/pom.xml
+++ b/fop-events/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>xmlgraphics-commons</artifactId>
-      <version>${xmlgraphics.commons.version}</version>
+      <version>2.3</version>
     </dependency>
     <!-- test-only deps -->
     <dependency>

--- a/fop-sandbox/pom.xml
+++ b/fop-sandbox/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>

--- a/fop-servlet/pom.xml
+++ b/fop-servlet/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>
@@ -25,13 +25,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>batik-all</artifactId>
-      <version>${batik.version}</version>
+      <version>1.10</version>
     </dependency>
     <!-- xgc deps -->
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>xmlgraphics-commons</artifactId>
-      <version>${xmlgraphics.commons.version}</version>
+      <version>2.3</version>
     </dependency>
     <!-- external deps -->
     <dependency>

--- a/fop-transcoder-allinone/pom.xml
+++ b/fop-transcoder-allinone/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>

--- a/fop-transcoder/pom.xml
+++ b/fop-transcoder/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>

--- a/fop-util/pom.xml
+++ b/fop-util/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>xmlgraphics-commons</artifactId>
-      <version>${xmlgraphics.commons.version}</version>
+      <version>2.3</version>
     </dependency>
     <!-- test deps -->
     <dependency>

--- a/fop/pom.xml
+++ b/fop/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>fop-parent</artifactId>
-    <version>2.3</version>
+    <version>2.3-FOP-2704.1</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.apache.xmlgraphics</groupId>
   <artifactId>fop-parent</artifactId>
-  <version>2.3</version>
+  <version>2.3-FOP-2704.1</version>
   <name>Apache FOP Parent</name>
   <description>XML Graphics Format Object Processor</description>
   <packaging>pom</packaging>


### PR DESCRIPTION
This applies the patch brought forward by Neil Smeby in https://issues.apache.org/jira/browse/FOP-2704. In short, it works around the `UnsupportedOperationException: coverage set class table not yet supported` exception when trying to use Google's Roboto font (updated 2017). 

Maven `${version}` placeholders are replaced with plain versions to work around a [potential issue in Jitpack.io](https://twitter.com/mpdude_de/status/1149410509541822464). 

See https://jitpack.io/#webfactory/fop/da392ffca how you can easily give this patch a try with your preferred build system.
 